### PR TITLE
Import via re-mapping

### DIFF
--- a/src/BN254.sol
+++ b/src/BN254.sol
@@ -14,7 +14,7 @@
 
 pragma solidity ^0.8.0;
 
-import "src/Utils.sol";
+import "bn254/Utils.sol";
 
 /// @notice Barreto-Naehrig curve over a 254 bit prime field
 library BN254 {


### PR DESCRIPTION
This seems to fix problems with etherscan verification via foundry.

No changes were needed in the espresso-sequencer repo.