### PR TITLE
fix: allow neutral point to pass ValidateG1Point with more tests

### DIFF
--- a/diff-test/src/lib.rs
+++ b/diff-test/src/lib.rs
@@ -80,7 +80,7 @@ where
         if p == ParsedG1Point::default() {
             Self::default()
         } else {
-            Self::new(
+            Self::new_unchecked(
                 u256_to_field::<P::BaseField>(p.x),
                 u256_to_field::<P::BaseField>(p.y),
             )
@@ -110,7 +110,7 @@ where
     C: Fp2Config,
 {
     fn from(p: ParsedG2Point) -> Self {
-        Self::new(
+        Self::new_unchecked(
             Fp2::new(u256_to_field(p.x0), u256_to_field(p.x1)),
             Fp2::new(u256_to_field(p.y0), u256_to_field(p.y1)),
         )

--- a/flake.lock
+++ b/flake.lock
@@ -125,15 +125,16 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1700471370,
-        "narHash": "sha256-WpR2ujGPB4HaqS3S3b2d5wc7hOPMVByumHgt//Z7b0Y=",
+        "lastModified": 1701270599,
+        "narHash": "sha256-6JNWZuON189C2pJci7jBBXtJqGPO9UKEKGzHY9dTGKs=",
         "owner": "shazow",
         "repo": "foundry.nix",
-        "rev": "8f9d67ec076cf7203c562c00f85303bae1280c10",
+        "rev": "1d4d9d015a64e9921f8837a83941d93182d92a71",
         "type": "github"
       },
       "original": {
         "owner": "shazow",
+        "ref": "monthly",
         "repo": "foundry.nix",
         "type": "github"
       }

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,13 @@
+(import
+  (
+    let
+      lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+    in
+    fetchTarball {
+      url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+      sha256 = lock.nodes.flake-compat.locked.narHash;
+    }
+  )
+  {
+    src = ./.;
+  }).shellNix

--- a/src/BN254.sol
+++ b/src/BN254.sol
@@ -204,24 +204,25 @@ library BN254 {
 
     /**
      * validate the following:
-     *   x != 0
-     *   y != 0
      *   x < p
      *   y < p
-     *   y^2 = x^3 + 3 mod p
+     *   y^2 = x^3 + 3 mod p or Point-of-Infinity
      */
     /// @dev validate G1 point and check if it is on curve
     /// @notice credit: Aztec, Spilsbury Holdings Ltd
     function validateG1Point(G1Point memory point) internal pure {
         bool isWellFormed;
         uint256 p = P_MOD;
+        if (isInfinity(point)) {
+            return;
+        }
         assembly {
             let x := mload(point)
             let y := mload(add(point, 0x20))
 
             isWellFormed :=
                 and(
-                    and(and(lt(x, p), lt(y, p)), not(or(iszero(x), iszero(y)))),
+                    and(lt(x, p), lt(y, p)),
                     eq(mulmod(y, y, p), addmod(mulmod(x, mulmod(x, x, p), p), 3, p))
                 )
         }

--- a/test/BN254.t.sol
+++ b/test/BN254.t.sol
@@ -43,6 +43,86 @@ contract BN254_P2_Test is BN254CommonTest {
     }
 }
 
+contract BN254_scalarMul_Test is BN254CommonTest {
+    /// @dev Test some edge cases
+    function test_EdgeCases() external {
+        assertEqG1Point(BN254.scalarMul(BN254.P1(), BN254.ScalarField.wrap(0)), BN254.infinity());
+        assertEqG1Point(BN254.scalarMul(BN254.P1(), BN254.ScalarField.wrap(1)), BN254.P1());
+        // generator ^ -1
+        BN254.G1Point memory genInv = BN254.G1Point(
+            BN254.BaseField.wrap(1),
+            BN254.BaseField.wrap(0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd45)
+        );
+        assertEqG1Point(
+            BN254.scalarMul(BN254.P1(), BN254.ScalarField.wrap(BN254.R_MOD - 1)), genInv
+        );
+        assertEqG1Point(
+            BN254.scalarMul(BN254.P1(), BN254.ScalarField.wrap(BN254.R_MOD)), BN254.infinity()
+        );
+        assertEqG1Point(
+            BN254.scalarMul(BN254.P1(), BN254.ScalarField.wrap(BN254.R_MOD + 1)), BN254.P1()
+        );
+    }
+
+    /// @dev Test scalarMul matches results from arkworks
+    function testFuzz_scalarMul_matches(uint256 randScalar) external {
+        string[] memory cmds = new string[](3);
+        cmds[0] = "diff-test";
+        cmds[1] = "bn254-g1-from-scalar";
+        cmds[2] = vm.toString(bytes32(randScalar));
+
+        bytes memory result = vm.ffi(cmds);
+        (BN254.G1Point memory point) = abi.decode(result, (BN254.G1Point));
+
+        assertEqG1Point(point, BN254.scalarMul(BN254.P1(), BN254.ScalarField.wrap(randScalar)));
+    }
+}
+
+contract BN254_validateG1Point_Test is BN254CommonTest {
+    /// @dev Test some valid edge-case points
+    function test_EdgeCases() external pure {
+        BN254.validateG1Point(BN254.P1());
+        BN254.validateG1Point(BN254.infinity());
+        BN254.validateG1Point(BN254.negate(BN254.P1()));
+        // generator ^ -1
+        BN254.G1Point memory genInv = BN254.G1Point(
+            BN254.BaseField.wrap(1),
+            BN254.BaseField.wrap(0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd45)
+        );
+        BN254.validateG1Point(genInv);
+    }
+
+    /// @dev Test random valid points should pass
+    function testFuzz_ValidPointShouldPass(uint256 randScalar) external {
+        string[] memory cmds = new string[](3);
+        cmds[0] = "diff-test";
+        cmds[1] = "bn254-g1-from-scalar";
+        cmds[2] = vm.toString(bytes32(randScalar));
+
+        bytes memory result = vm.ffi(cmds);
+        (BN254.G1Point memory point) = abi.decode(result, (BN254.G1Point));
+
+        // valid point should pass
+        BN254.validateG1Point(point);
+    }
+
+    /// @dev Test invalid points should cause revert
+    function test_RevertWhenInvalidPoint(BN254.G1Point memory point) external {
+        string[] memory cmds = new string[](3);
+        cmds[0] = "diff-test";
+        cmds[1] = "bn254-g1-is-on-curve";
+        cmds[2] = vm.toString(abi.encode(point));
+
+        bytes memory result = vm.ffi(cmds);
+        (bool isOnCurve) = abi.decode(result, (bool));
+
+        if (!isOnCurve) {
+            vm.expectRevert("Bn254: invalid G1 point");
+            BN254.validateG1Point(point);
+        }
+    }
+}
+
 contract BN254_pairingProd2_Test is BN254CommonTest {
     /// @dev Test pairingProd2 function with random G1, G2 pairs,
     /// fuzzer only generate random seed, actual random pairs are generated in diff-test


### PR DESCRIPTION
The changes include:
- Allow `BN254.infinity()` to pass `ValidG1Point()` check.
- Add tests for both `validateG1Point()` and `scalarMul()` functions


credit: thanks to @philippecamacho for spotting this gap during a downstream fuzzing.