### PR TITLE
chore: rename diff-test lib crate and use pub visibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,5 +48,5 @@ jobs:
 
       - name: Run tests
         run: |
-          nix develop --accept-flake-config -c cargo build --bin diff-test --release
+          nix develop --accept-flake-config -c cargo build --bin diff-test-bn254 --release
           nix develop --accept-flake-config -c forge test -vvv

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -778,7 +778,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
-name = "diff-test"
+name = "diff-test-bn254"
 version = "0.1.0"
 dependencies = [
  "ark-bn254",

--- a/diff-test/Cargo.toml
+++ b/diff-test/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
-name = "diff-test"
+name = "diff-test-bn254"
+description = "Structs, type conversion and differential test scripts for solidity-bn254"
 authors = { workspace = true }
 edition = { workspace = true }
 version = { workspace = true }

--- a/diff-test/src/lib.rs
+++ b/diff-test/src/lib.rs
@@ -30,8 +30,10 @@ pub fn u256_to_field<F: PrimeField>(x: U256) -> F {
 /// an intermediate representation of `BN254.G1Point` in solidity.
 #[derive(Clone, PartialEq, Eq, Debug, EthAbiType, EthAbiCodec)]
 pub struct ParsedG1Point {
-    x: U256,
-    y: U256,
+    /// x coordinate of affine repr
+    pub x: U256,
+    /// y coordinate of affine repr
+    pub y: U256,
 }
 
 // this is convention from BN256 precompile
@@ -91,10 +93,14 @@ where
 /// Intermediate representation of `G2Point` in Solidity
 #[derive(Clone, PartialEq, Eq, Debug, EthAbiType, EthAbiCodec)]
 pub struct ParsedG2Point {
-    x0: U256,
-    x1: U256,
-    y0: U256,
-    y1: U256,
+    /// x0 of x = x0 + u * x1 coordinate
+    pub x0: U256,
+    /// x1 of x = x0 + u * x1 coordinate
+    pub x1: U256,
+    /// y0 of y = y0 + u * y1 coordinate
+    pub y0: U256,
+    /// y1 of y = y0 + u * y1 coordinate
+    pub y1: U256,
 }
 
 impl FromStr for ParsedG2Point {

--- a/diff-test/src/main.rs
+++ b/diff-test/src/main.rs
@@ -7,7 +7,7 @@ use ark_std::{
 use clap::{Parser, ValueEnum};
 use ethers::{abi::AbiEncode, types::U256};
 
-use diff_test::{u256_to_field, ParsedG1Point, ParsedG2Point};
+use diff_test_bn254::{u256_to_field, ParsedG1Point, ParsedG2Point};
 
 #[derive(Parser)]
 #[command(author, version, about, long_about=None)]

--- a/justfile
+++ b/justfile
@@ -3,5 +3,5 @@ default:
 
 # Build diff-test binary and forge test
 sol-test:
-    cargo build --bin diff-test --release
+    cargo build --bin diff-test-bn254 --release
     forge test

--- a/test/BN254.t.sol
+++ b/test/BN254.t.sol
@@ -33,7 +33,7 @@ contract BN254_P2_Test is BN254CommonTest {
     /// @dev Test if the G2 generator matches with arkworks
     function test_p2_matches() external {
         string[] memory cmds = new string[](2);
-        cmds[0] = "diff-test";
+        cmds[0] = "diff-test-bn254";
         cmds[1] = "bn254-g2-gen";
 
         bytes memory result = vm.ffi(cmds);
@@ -67,7 +67,7 @@ contract BN254_scalarMul_Test is BN254CommonTest {
     /// @dev Test scalarMul matches results from arkworks
     function testFuzz_scalarMul_matches(uint256 randScalar) external {
         string[] memory cmds = new string[](3);
-        cmds[0] = "diff-test";
+        cmds[0] = "diff-test-bn254";
         cmds[1] = "bn254-g1-from-scalar";
         cmds[2] = vm.toString(bytes32(randScalar));
 
@@ -95,7 +95,7 @@ contract BN254_validateG1Point_Test is BN254CommonTest {
     /// @dev Test random valid points should pass
     function testFuzz_ValidPointShouldPass(uint256 randScalar) external {
         string[] memory cmds = new string[](3);
-        cmds[0] = "diff-test";
+        cmds[0] = "diff-test-bn254";
         cmds[1] = "bn254-g1-from-scalar";
         cmds[2] = vm.toString(bytes32(randScalar));
 
@@ -109,7 +109,7 @@ contract BN254_validateG1Point_Test is BN254CommonTest {
     /// @dev Test invalid points should cause revert
     function test_RevertWhenInvalidPoint(BN254.G1Point memory point) external {
         string[] memory cmds = new string[](3);
-        cmds[0] = "diff-test";
+        cmds[0] = "diff-test-bn254";
         cmds[1] = "bn254-g1-is-on-curve";
         cmds[2] = vm.toString(abi.encode(point));
 
@@ -125,10 +125,10 @@ contract BN254_validateG1Point_Test is BN254CommonTest {
 
 contract BN254_pairingProd2_Test is BN254CommonTest {
     /// @dev Test pairingProd2 function with random G1, G2 pairs,
-    /// fuzzer only generate random seed, actual random pairs are generated in diff-test
+    /// fuzzer only generate random seed, actual random pairs are generated in diff-test-bn254
     function testFuzz_pairingProd2_matches(uint64 seed) external {
         string[] memory cmds = new string[](3);
-        cmds[0] = "diff-test";
+        cmds[0] = "diff-test-bn254";
         cmds[1] = "bn254-pairing-prod2";
         cmds[2] = vm.toString(seed);
 
@@ -140,7 +140,7 @@ contract BN254_pairingProd2_Test is BN254CommonTest {
             BN254.G2Point memory b2
         ) = abi.decode(result, (BN254.G1Point, BN254.G2Point, BN254.G1Point, BN254.G2Point));
 
-        // when seed % 2 == 1, diff-test will generate pairs that satisfy the pairing product
+        // when seed % 2 == 1, diff-test-bn254 will generate pairs that satisfy the pairing product
         // else it will generate unsatisyfing pairs
         if (seed % 2 == 0) {
             assert(!BN254.pairingProd2(a1, a2, b1, b2));


### PR DESCRIPTION
Major changes include:
- rename `diff-test` to `diff-test-bn254` for better downstream import (avoiding potential crate name clashes)
- change fields of `struct ParsedG1Point` and `struct ParsedG2Point` to be public