### PR TITLE
fix: g1Deserialize should revert on non-canonical x coordinate

### DIFF
--- a/src/BN254.sol
+++ b/src/BN254.sol
@@ -311,6 +311,7 @@ library BN254 {
         return result;
     }
 
+    // TODO: remove endian conversion in <https://github.com/EspressoSystems/espresso-sequencer/issues/1739>
     function g1Serialize(G1Point memory point) internal pure returns (bytes memory) {
         uint256 mask = 0;
 
@@ -329,8 +330,13 @@ library BN254 {
         return abi.encodePacked(Utils.reverseEndianness(BaseField.unwrap(point.x) | mask));
     }
 
+    /// @dev for big endian u256 input, the first two leading bits (255-th and 254-th)
+    /// 00: negativeY; 10: positiveY; 01/11: infinity
+    /// for the remaining 254-bit value, canonical representation refers to the smallest
+    /// non-negative integer for every field element.
     function g1Deserialize(bytes32 input) internal view returns (G1Point memory point) {
         uint256 mask = 0x4000000000000000000000000000000000000000000000000000000000000000;
+        // TODO: remove endian conversion in <https://github.com/EspressoSystems/espresso-sequencer/issues/1739>
         uint256 xVal = Utils.reverseEndianness(uint256(input));
         bool isQuadraticResidue;
         bool isYPositive;
@@ -344,6 +350,8 @@ library BN254 {
             // mask off the first two bits of x
             mask = 0x3FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
             xVal &= mask;
+
+            require(xVal < P_MOD, "deser fail: non-canonical repr");
 
             // solve for y where E: y^2 = x^3 + 3
             BaseField x = BaseField.wrap(xVal);

--- a/test/BN254.t.sol
+++ b/test/BN254.t.sol
@@ -167,6 +167,16 @@ contract BN254_serde_Test is BN254CommonTest {
         // change to non-canonical representation
         p1.x = BN254.BaseField.wrap(1 + BN254.P_MOD);
 
+        // non-canonical representation is still valid and onCurve
+        string[] memory cmds = new string[](3);
+        cmds[0] = "diff-test-bn254";
+        cmds[1] = "bn254-g1-is-on-curve";
+        cmds[2] = vm.toString(abi.encode(p1));
+        bytes memory result = vm.ffi(cmds);
+        (bool isOnCurve) = abi.decode(result, (bool));
+        assert(isOnCurve);
+
+        // but should fail our deserialization
         vm.expectRevert("deser fail: non-canonical repr");
         BN254.g1Deserialize(bytes32(BN254.g1Serialize(p1)));
     }


### PR DESCRIPTION
Closes https://github.com/EspressoSystems/espresso-sequencer/issues/1730


### This PR:

implemented the suggestion:
> Suggestion: We suggest that the function reverts if the x-coordinate is not canonical.

and add tests
