### PR TITLE
fix: Revert on empty array for MSM

### DIFF
--- a/src/BN254.sol
+++ b/src/BN254.sol
@@ -175,7 +175,8 @@ library BN254 {
         view
         returns (G1Point memory r)
     {
-        require(scalars.length == bases.length, "MSM error: length does not match");
+        require(scalars.length == bases.length, "MSM err: length does not match");
+        require(bases.length > 0, "MSM err: empty bases/scalars");
 
         r = scalarMul(bases[0], scalars[0]);
         for (uint256 i = 1; i < scalars.length; i++) {

--- a/test/BN254.t.sol
+++ b/test/BN254.t.sol
@@ -78,6 +78,31 @@ contract BN254_scalarMul_Test is BN254CommonTest {
     }
 }
 
+contract BN254_multiScalarMul_Test is BN254CommonTest {
+    function test_revertWhenEmptyArray() external {
+        BN254.G1Point[] memory bases;
+        BN254.ScalarField[] memory scalars;
+        assert(bases.length == 0 && scalars.length == 0);
+        vm.expectRevert("MSM err: empty bases/scalars");
+        BN254.multiScalarMul(bases, scalars);
+    }
+
+    function test_msm() external {
+        uint64 numBases = 5;
+
+        string[] memory cmds = new string[](3);
+        cmds[0] = "diff-test-bn254";
+        cmds[1] = "bn254-msm";
+        cmds[2] = vm.toString(numBases);
+
+        bytes memory result = vm.ffi(cmds);
+        (BN254.G1Point[] memory bases, BN254.ScalarField[] memory scalars, BN254.G1Point memory res)
+        = abi.decode(result, (BN254.G1Point[], BN254.ScalarField[], BN254.G1Point));
+
+        assertEqG1Point(res, BN254.multiScalarMul(bases, scalars));
+    }
+}
+
 contract BN254_validateG1Point_Test is BN254CommonTest {
     /// @dev Test some valid edge-case points
     function test_EdgeCases() external pure {


### PR DESCRIPTION
Closes https://github.com/EspressoSystems/espresso-sequencer/issues/1754

### This PR:

- Revert on empty array input
- add test for this revert
- add test for normal MSM

