### PR TITLE
refactor!: Use big endian compressed form for G1 serde

### DIFF
--- a/src/BN254.sol
+++ b/src/BN254.sol
@@ -315,14 +315,14 @@ library BN254 {
         return result;
     }
 
-    // TODO: remove endian conversion in <https://github.com/EspressoSystems/espresso-sequencer/issues/1739>
-    function g1Serialize(G1Point memory point) internal pure returns (bytes memory) {
+    /// @dev Serialize G1 point, compressed, big-endian form
+    function g1Serialize(G1Point memory point) internal pure returns (bytes32) {
         uint256 mask = 0;
 
         // Set the 254-th bit to 1 for infinity
         // https://docs.rs/ark-serialize/0.3.0/src/ark_serialize/flags.rs.html#117
         if (isInfinity(point)) {
-            return bytes("0x4000000000000000000000000000000000000000000000000000000000000000");
+            return bytes32(0x4000000000000000000000000000000000000000000000000000000000000000);
         }
 
         // Set the 255-th bit to 1 for positive Y
@@ -331,7 +331,7 @@ library BN254 {
             mask = 0x8000000000000000000000000000000000000000000000000000000000000000;
         }
 
-        return abi.encodePacked(Utils.reverseEndianness(BaseField.unwrap(point.x) | mask));
+        return bytes32(BaseField.unwrap(point.x) | mask);
     }
 
     /// @dev for big endian u256 input, the first two leading bits (255-th and 254-th)
@@ -340,8 +340,7 @@ library BN254 {
     /// non-negative integer for every field element.
     function g1Deserialize(bytes32 input) internal view returns (G1Point memory point) {
         uint256 mask = 0x4000000000000000000000000000000000000000000000000000000000000000;
-        // TODO: remove endian conversion in <https://github.com/EspressoSystems/espresso-sequencer/issues/1739>
-        uint256 xVal = Utils.reverseEndianness(uint256(input));
+        uint256 xVal = uint256(input);
         bool isQuadraticResidue;
         bool isYPositive;
         if (xVal & mask != 0) {

--- a/test/BN254.t.sol
+++ b/test/BN254.t.sol
@@ -205,4 +205,17 @@ contract BN254_serde_Test is BN254CommonTest {
         vm.expectRevert("deser fail: non-canonical repr");
         BN254.g1Deserialize(bytes32(BN254.g1Serialize(p1)));
     }
+
+    /// @dev Test correctness: deser(ser(x)) == x
+    function testFuzz_ShouldDeserializeToSerializedPoint(uint256 randScalar) external {
+        string[] memory cmds = new string[](3);
+        cmds[0] = "diff-test-bn254";
+        cmds[1] = "bn254-g1-from-scalar";
+        cmds[2] = vm.toString(bytes32(randScalar));
+
+        bytes memory result = vm.ffi(cmds);
+        (BN254.G1Point memory point) = abi.decode(result, (BN254.G1Point));
+
+        assertEqG1Point(point, BN254.g1Deserialize(bytes32(BN254.g1Serialize(point))));
+    }
 }


### PR DESCRIPTION
Part of https://github.com/EspressoSystems/espresso-sequencer/issues/1739

### This PR:

- Removed endian reversal during serialize and deserialize of G1 point

### This PR does not:

Provides a rust equivalent method. Currently arkwork's out-of-box API doesn't have a straightforward code the correspond this version of serde logic. 
the default `to_bytes!()` use compressed, little-endian form. 
We can choose `CanonicalSerialize::serialize(x, Compress::False)` to use uncompressed but still little-endian form.
We can also use `field.into_bigint().to_bytes_be()` to use big-endian, but we have to manually compress (and decompress). 

Additionally, I'm not using this `g1Serialize()` anymore in `PlonkVerifier.sol` anymore, so I'd suggest we keep this as a draft PR and only merge if we really want to keep these two APIs. 
lmk if you disagree @philippecamacho 