### PR TITLE
Improvements related to staticcall() invocations

### DIFF
--- a/src/BN254.sol
+++ b/src/BN254.sol
@@ -127,9 +127,6 @@ library BN254 {
         bool success;
         assembly {
             success := staticcall(sub(gas(), 2000), 6, input, 0xc0, r, 0x60)
-            // Use "invalid" to make gas estimation work
-            switch success
-            case 0 { revert(0, 0) }
         }
         require(success, "Bn254: group addition failed!");
     }
@@ -164,9 +161,6 @@ library BN254 {
         bool success;
         assembly {
             success := staticcall(sub(gas(), 2000), 7, input, 0x80, r, 0x60)
-            // Use "invalid" to make gas estimation work
-            switch success
-            case 0 { revert(0, 0) }
         }
         require(success, "Bn254: scalar mul failed!");
     }

--- a/src/BN254.sol
+++ b/src/BN254.sol
@@ -126,7 +126,7 @@ library BN254 {
         input[3] = BaseField.unwrap(p2.y);
         bool success;
         assembly {
-            success := staticcall(sub(gas(), 2000), 6, input, 0xc0, r, 0x60)
+            success := staticcall(gas(), 6, input, 0x80, r, 0x40)
         }
         require(success, "Bn254: group addition failed!");
     }
@@ -160,7 +160,7 @@ library BN254 {
         input[2] = ScalarField.unwrap(s);
         bool success;
         assembly {
-            success := staticcall(sub(gas(), 2000), 7, input, 0x80, r, 0x60)
+            success := staticcall(gas(), 7, input, 0x60, r, 0x40)
         }
         require(success, "Bn254: scalar mul failed!");
     }


### PR DESCRIPTION
Closes https://github.com/EspressoSystems/espresso-sequencer/issues/1745 and  https://github.com/EspressoSystems/espresso-sequencer/issues/1749

### This PR:
* Remove the success checks for `staticall()` invocations as suggested in https://github.com/EspressoSystems/espresso-sequencer/issues/1745.

* Pass the right parameters to `staticcall()`  invocations as suggested in https://github.com/EspressoSystems/espresso-sequencer/issues/1749