### PR TITLE
Set the return type of fuction g1Serialize to bytes32.

### DIFF
--- a/src/BN254.sol
+++ b/src/BN254.sol
@@ -310,13 +310,13 @@ library BN254 {
     }
 
     // TODO: remove endian conversion in <https://github.com/EspressoSystems/espresso-sequencer/issues/1739>
-    function g1Serialize(G1Point memory point) internal pure returns (bytes memory) {
+    function g1Serialize(G1Point memory point) internal pure returns (bytes32) {
         uint256 mask = 0;
 
         // Set the 254-th bit to 1 for infinity
         // https://docs.rs/ark-serialize/0.3.0/src/ark_serialize/flags.rs.html#117
         if (isInfinity(point)) {
-            return bytes("0x4000000000000000000000000000000000000000000000000000000000000000");
+            return 0x4000000000000000000000000000000000000000000000000000000000000000;
         }
 
         // Set the 255-th bit to 1 for positive Y
@@ -325,7 +325,7 @@ library BN254 {
             mask = 0x8000000000000000000000000000000000000000000000000000000000000000;
         }
 
-        return abi.encodePacked(Utils.reverseEndianness(BaseField.unwrap(point.x) | mask));
+        return bytes32(Utils.reverseEndianness(BaseField.unwrap(point.x) | mask));
     }
 
     /// @dev for big endian u256 input, the first two leading bits (255-th and 254-th)


### PR DESCRIPTION
Closes https://github.com/EspressoSystems/espresso-sequencer/issues/1746

### This PR:
Set the return type of fuction g1Serialize to bytes32. as suggested in https://github.com/EspressoSystems/espresso-sequencer/issues/1746.