### PR TITLE
fix: add back scalar negate and quadResidue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -949,7 +949,6 @@ dependencies = [
  "ark-ff 0.4.2",
  "ark-std 0.4.0",
  "clap",
- "const-hex",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,3 @@ ark-poly = "0.4.2"
 ark-serialize = "0.4.2"
 ark-std = { version = "0.4.0", default-features = false }
 alloy = { version = "0.12.5", default-features = false, features = ["contract", "sol-types"] }
-const-hex = "1.14.0"

--- a/diff-test/Cargo.toml
+++ b/diff-test/Cargo.toml
@@ -12,7 +12,6 @@ ark-ec = { workspace = true }
 ark-ff = { workspace = true }
 ark-std = { workspace = true }
 clap = { version = "^4.4", features = ["derive"] }
-const-hex = { workspace = true }
 
 [[bin]]
 name = "diff-test-bn254"

--- a/diff-test/src/main.rs
+++ b/diff-test/src/main.rs
@@ -1,13 +1,17 @@
-use alloy::{primitives::U256, sol_types::SolValue};
+use alloy::{
+    hex::{self, ToHexExt},
+    primitives::U256,
+    sol_types::SolValue,
+};
 use ark_bn254::{Bn254, Fr, G1Affine, G2Affine};
 use ark_ec::{pairing::Pairing, short_weierstrass::SWCurveConfig, AffineRepr, CurveGroup, Group};
+use ark_ff::Field;
 use ark_std::{
     rand::{rngs::StdRng, SeedableRng},
     test_rng, UniformRand,
 };
 use bn254_contract_adapter::{field_to_u256, u256_to_field, G1Point, G2Point};
 use clap::{Parser, ValueEnum};
-use const_hex::ToHexExt;
 
 #[derive(Parser)]
 #[command(author, version, about, long_about=None)]
@@ -32,6 +36,14 @@ enum Action {
     Bn254PairingProd2,
     /// Generate bases and scalars for MSM computation
     Bn254MSM,
+    /// Compute inverse op in the scalar field
+    Bn254ScalarInvOp,
+    /// Compute negate op in the scalar field
+    Bn254ScalarNegOp,
+    /// Compute add op in the G1 group
+    Bn254G1AddOp,
+    /// Compute negate op in the G1 group
+    Bn254G1NegOp,
     /// Test only logic
     TestOnly,
 }
@@ -56,10 +68,9 @@ fn main() {
             if cli.args.len() != 1 {
                 panic!("Should provide arg1=point");
             }
-            let point: G1Affine =
-                G1Point::abi_decode(&const_hex::decode(&cli.args[0]).unwrap(), true)
-                    .unwrap()
-                    .into();
+            let point: G1Affine = G1Point::abi_decode(&hex::decode(&cli.args[0]).unwrap(), true)
+                .unwrap()
+                .into();
             let is_on_curve = point.is_on_curve();
             println!("{}", is_on_curve.abi_encode().encode_hex());
         }
@@ -120,6 +131,56 @@ fn main() {
             let res = (parsed_bases, parsed_scalars, parsed_prod);
             println!("{}", res.abi_encode_params().encode_hex());
         }
+        Action::Bn254ScalarInvOp => {
+            if cli.args.len() != 1 {
+                panic!("Should provide arg1=scalar");
+            }
+
+            let s: Fr = u256_to_field(cli.args[0].parse::<U256>().unwrap());
+            let res = field_to_u256(s.inverse().unwrap());
+            println!("{}", res.abi_encode().encode_hex());
+        }
+        Action::Bn254ScalarNegOp => {
+            if cli.args.len() != 1 {
+                panic!("Should provide arg1=scalar");
+            }
+
+            let s: Fr = u256_to_field(cli.args[0].parse::<U256>().unwrap());
+            let res = field_to_u256(-s);
+            println!("{}", res.abi_encode().encode_hex());
+        }
+        Action::Bn254G1AddOp => {
+            if cli.args.len() != 1 {
+                panic!("Should provide arg1=seed");
+            }
+            let seed = cli.args[0].parse::<u64>().unwrap();
+            let rng = &mut StdRng::seed_from_u64(seed);
+
+            let a = G1Affine::rand(rng);
+            let b = G1Affine::rand(rng);
+            let sum = a + b;
+
+            let a_sol: G1Point = a.into();
+            let b_sol: G1Point = b.into();
+            let sum_sol: G1Point = sum.into_affine().into();
+            println!(
+                "{}",
+                (a_sol, b_sol, sum_sol).abi_encode_params().encode_hex()
+            );
+        }
+        Action::Bn254G1NegOp => {
+            if cli.args.len() != 1 {
+                panic!("Should provide arg1=seed");
+            }
+            let seed = cli.args[0].parse::<u64>().unwrap();
+            let rng = &mut StdRng::seed_from_u64(seed);
+
+            let a = G1Affine::rand(rng);
+            let a_sol: G1Point = a.into();
+            let neg_sol: G1Point = (-a).into();
+            println!("{}", (a_sol, neg_sol).abi_encode_params().encode_hex());
+        }
+
         Action::TestOnly => {
             eprintln!("test only");
         }

--- a/src/BN254.sol
+++ b/src/BN254.sol
@@ -66,7 +66,7 @@ library BN254 {
 
     error BN254G1AddFailed();
     error BN254ScalarMulFailed();
-    error BN254ScalarInvFailed();
+    error PowPrecompileFailed();
     error BN254ScalarInvZero();
     error BN254PairingProdFailed();
     error InvalidArgs();
@@ -114,8 +114,18 @@ library BN254 {
         }
         return G1Point(p.x, BaseField.wrap(P_MOD - (BaseField.unwrap(p.y) % P_MOD)));
     }
-    /// @return r the sum of two points of G1
 
+    /// @return res = -fr the negation of scalar field element.
+    function negate(ScalarField fr) internal pure returns (ScalarField res) {
+        uint256 p = R_MOD;
+        assembly {
+            switch iszero(fr)
+            case true { res := 0 }
+            default { res := sub(p, fr) }
+        }
+    }
+
+    /// @return r the sum of two points of G1
     function add(G1Point memory p1, G1Point memory p2) internal view returns (G1Point memory r) {
         uint256[4] memory input;
         input[0] = BaseField.unwrap(p1.x);
@@ -176,7 +186,7 @@ library BN254 {
             success := staticcall(gas(), 0x05, mPtr, 0xc0, 0x00, 0x20)
             output := mload(0x00)
         }
-        require(success, BN254ScalarInvFailed());
+        require(success, PowPrecompileFailed());
     }
 
     /**


### PR DESCRIPTION
Followup of #23 


### This PR:

As I try to use the latest BN254 library, I realize that I have excessively pruned some functions that we actually use, including `negate(ScalarField)` and `quadraticResidue()`, thus I add them back and with diff-test